### PR TITLE
chore: Exclude Microsoft.NET.Test.Sdk from updates

### DIFF
--- a/Tests/Approval.Tests/Approval.Tests.csproj
+++ b/Tests/Approval.Tests/Approval.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/AwesomeAssertions.Json.Specs/AwesomeAssertions.Json.Specs.csproj
+++ b/Tests/AwesomeAssertions.Json.Specs/AwesomeAssertions.Json.Specs.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,8 @@
     ],
 	"ignoreDeps": [
         "Newtonsoft.Json",
-        "AwesomeAssertions"
+        "AwesomeAssertions",
+        "Microsoft.NET.Test.Sdk"
     ],
     "packageRules": [
         {


### PR DESCRIPTION
* Exclude Microsoft.NET.Test.Sdk from updates, because version >= 17.14.0 collides with our referenced version of Newtonsoft.Json