### PR TITLE
Enable automatic upgrade of build packages

### DIFF
--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -14,8 +14,10 @@
     <PackageReference Include="Fallout.Common" Version="10.3.49" />
     <PackageDownload Include="GitVersion.Tool" Version="[6.5.1]" />
     <PackageDownload Include="ReportGenerator" Version="[5.5.0]" />
-    <!-- Replace the implicitly referenced version 6.12.1, which is defined by the package Nuke.Common and has known vulnerabilities, with a fixed version -->
+    <!-- Replace the implicitly referenced version 6.12.1, which is defined by the package Fallout.Common and has known vulnerabilities, with a fixed version -->
     <PackageReference Include="Nuget.Packaging" Version="7.3.1" />
+    <!-- Replace the implicitly referenced version 10.0.6, which is defined by the package Fallout.Common and has known vulnerabilities, with a fixed version -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,11 +4,6 @@
     "extends": [ "config:recommended" ],
     "ignorePresets": [ ":ignoreModulesAndTests" ],
 
-    // Do not update the build project.
-    // NUKE sometimes change API break without major version.
-    // Let's update manually.
-    "ignorePaths": [ "Build/**" ],
-    
     // Do not automatically update because that's breaking
     "ignoreDeps": [ "Newtonsoft.Json", "AwesomeAssertions" ],
     "packageRules": [
@@ -18,10 +13,12 @@
             "schedule": [ "* * 1 * *" ]
         },
 
-        // Disable updates for pinned packages.
+        // Disable updates for pinned packages for Src and Tests.
+        // The Build project must have some pinned versions because dotnet allows only exact versions with PackageDownload
         // https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/nuget/readme.md#disabling-updates-for-pinned-versions
         {
-            "matchManagers": [ "nuget" ],
+            "matchManagers": ["nuget"],
+            "matchFileNames": ["Src/**", "Tests/**"],
             "matchCurrentValue": "/^\\[[^,]+\\]$/",
             "enabled": false
         }


### PR DESCRIPTION
Enable automatic package updates for PackageDownload references in build project, which are required by dotnet to have exact versions. Renovate should still be able to update them.